### PR TITLE
Sanitizing file name in cases where file name includes forbidden characters

### DIFF
--- a/src/utils/createNote.ts
+++ b/src/utils/createNote.ts
@@ -20,11 +20,7 @@ export async function createNoteInFolder(
 		return null;
 	}
 
-	function sanitizeFileName(input: string): string {
-		return input.replace(/[\\/:*?"<>|]/g, '');
-	}
-
-	const sanitizedTitle = sanitizeFileName(title);
+	const sanitizedTitle = title.replaceAll(`"`, `'`).replace(/[\\/:*?]/g, '~');
 	const filePath = normalizePath(`${folderPath}/${sanitizedTitle}.md`);
 	const file = app.vault.getAbstractFileByPath(filePath);
 

--- a/src/utils/createNote.ts
+++ b/src/utils/createNote.ts
@@ -20,7 +20,12 @@ export async function createNoteInFolder(
 		return null;
 	}
 
-	const filePath = normalizePath(`${folderPath}/${title}.md`);
+	function sanitizeFileName(input: string): string {
+		return input.replace(/[\\/:*?"<>|]/g, '');
+	}
+
+	const sanitizedTitle = sanitizeFileName(title);
+	const filePath = normalizePath(`${folderPath}/${sanitizedTitle}.md`);
 	const file = app.vault.getAbstractFileByPath(filePath);
 
 	if (file && !overrideExisting) {


### PR DESCRIPTION
Tested it, outputs "", or nothing, can be changed to "-" to distinguish that there was supposed to be something
Fix for Issue: #30 